### PR TITLE
Scalajs version upgrades + Char#isLetter workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION compile 'fastOptStage::testOnly T5514 scala.util.parsing.combinator.RegexParsersTest'
+  - sbt ++$TRAVIS_SCALA_VERSION 'set scalaJSStage in Global := FastOptStage' compile 'testOnly T5514 scala.util.parsing.combinator.RegexParsersTest'
 scala:
   - 2.11.1
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import bintray.Keys.{repository, bintrayOrganization, bintray}
 
-scalaJSSettings
+enablePlugins(ScalaJSPlugin)
 
 organization               := "org.scalajs"
 
@@ -10,7 +10,11 @@ version                    := "1.0.2"
 
 scalaVersion               := "2.11.1"
 
-utest.jsrunner.Plugin.utestJsSettings
+testFrameworks += new TestFramework("utest.runner.Framework")
+
+libraryDependencies ++= Seq(
+  "com.lihaoyi" %%% "utest" % "0.2.5-RC1" % "test"
+)
 
 homepage := Some(url("http://www.scala-js.org/"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.5.4")
-
-addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.2.3")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-RC1")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")

--- a/src/main/scala/scala/util/parsing/combinator/lexical/Lexical.scala
+++ b/src/main/scala/scala/util/parsing/combinator/lexical/Lexical.scala
@@ -13,6 +13,8 @@ package util.parsing
 package combinator
 package lexical
 
+import java.util.regex.Pattern
+
 import token._
 import input.CharArrayReader.EofCh
 
@@ -26,8 +28,11 @@ import input.CharArrayReader.EofCh
  */
 abstract class Lexical extends Scanners with Tokens {
 
+  private lazy val isLetterPattern = Pattern.compile("\\p{L}")
+
   /** A character-parser that matches a letter (and returns it).*/
-  def letter = elem("letter", _.isLetter)
+  // def letter = elem("letter", _.isLetter)
+  def letter = elem("letter", e => isLetterPattern.matcher(e.toString).matches())
 
   /** A character-parser that matches a digit (and returns it).*/
   def digit = elem("digit", _.isDigit)


### PR DESCRIPTION
Hi Sébastien,

I've been using it quite extensively and it seems to be working well on RC1. I need the `Char#isLetter` workaround though we talked about like 3 months ago (as it is not implemented in scala.js)... See `Lexical.scala` ... Imho it is not usable without it. 

I'll push following commits upgrading to 0.6.0 and scala 2.11.5 soon. I'll might try to rebase further commits that happened after you forked it.
